### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/bin/abbyy-to-hocr
+++ b/bin/abbyy-to-hocr
@@ -31,7 +31,7 @@ import io
 # X Add scan_res (from image or item metadata? meh)
 # X word confidence wordFromDictionary (?) + char confs?, 'suspicious' attribute
 # - Add lots of (strict) assertions to prevent silent bugs (unknown areas/types, etc)
-# - ocr_page image property - point to the some url for convience (where do we
+# - ocr_page image property - point to the some url for convenience (where do we
 #   get it from?)
 
 # Tested versions:

--- a/bin/hocr-combine-stream
+++ b/bin/hocr-combine-stream
@@ -61,7 +61,7 @@ def process_files(files_to_process):
             # Let's Remove the xmlns in the div.
             # Yes, this is horrible, but cleanup_namespaces doesn't help
             # since as far as tostring knows, this is the root.
-            # Let's also add two spaces for indendation for the first
+            # Let's also add two spaces for indentation for the first
             # page, and one for all the other pages.
             if page_no == 1:
                 s = '  ' + \
@@ -85,7 +85,6 @@ if __name__ == '__main__':
     files_to_process = glob(args.glob)
 
     if not len(files_to_process):
-        import sys
         print('No files to process!', file=sys.stderr)
         sys.exit(1)
 

--- a/bin/hocr-fold-chars
+++ b/bin/hocr-fold-chars
@@ -36,7 +36,7 @@ def process_files(infile):
         # Let's Remove the xmlns in the div.
         # Yes, this is horrible, but cleanup_namespaces doesn't help
         # since as far as tostring knows, this is the root.
-        # Let's also add two spaces for indendation for the first
+        # Let's also add two spaces for indentation for the first
         # page, and one for all the other pages.
         if page_no == 1:
             s = '  ' + \


### PR DESCRIPTION
[`codespell --skip="*.csv,*.json"`](https://pypi.org/project/codespell)