### PR TITLE
mention hocr_to_pdf in README, along with other undocumented tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,3 +11,6 @@ It also contains various tools:
   resulting file for an entire book.
 * ``hocr-fold-chars``: A tool to transform a per-character hocr file into a
   per-word hocr file.
+* ``pdf-to-hocr``: A tool to take text content embedded in a PDF, and extract
+  it as HOCR format.
+* See more tools in the ./bin directory, not all have been documented yet.


### PR DESCRIPTION
The pdf_to_hocr functionality is super useful for a variety of possible work/data flows (including manual correction workflows), and I'm not aware of any other open source implementation. I didn't realize it was in here at first -- even though I had glanced at this project -- until I was looking at source code for `pdfcomp` and saw it call this.  I figured it was worth mentioning in the README, along with mentioning more prominently the existence of other currently un-doc'd utilities the reader might want to look at. 

Thanks for the code!