### PR TITLE
Fix: use `iso-639` rather than `iso639`

### DIFF
--- a/bin/hocr-to-daisy
+++ b/bin/hocr-to-daisy
@@ -111,11 +111,20 @@ class DaisyGenerator:
         md = ET.parse(md_path).getroot()
         result = []
         for el in md:
-            if el.tag == 'language':
+            if el.tag == 'language' and el.text:
                 try:
-                    result_text = iso639.to_iso639_1(el.text)
-                except iso639.NonExistentLanguageError as e:
-                    print(f"Could not convert {el.text} to an iso639-1 code: {e}")
+                    # _meta.xml has 3 character language codes and language names, but
+                    # the DAISY spec requires two character codes.
+                    if len(el.text) == 3:
+                        result_text = iso639.languages.get(
+                            part2b=el.text.lower()
+                        ).alpha2
+                    else:
+                        result_text = iso639.languages.get(name=el.text.title()).alpha2
+                except KeyError as e:
+                    print(
+                        f"Could not convert {el.text} to an iso639-1 code. Invalid language key: {e}"
+                    )
                     result_text = el.text
             else:
                 result_text = el.text

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='archive-hocr-tools',
       include_package_data=True,
       install_requires=[],
       extras_require={
-          'daisy': ['iso639==0.1.4'],
+          'daisy': ['iso-639==0.4.5'],  # Note this is NOT the `iso639` package used by `epub`.
           'epub': ['ebooklib==0.17.1', 'internetarchive-deriver-module==1.0.1', 'iso639==0.1.4'],
           'pdf': ['PyMuPDF==1.22.5', 'numpy==1.21.3'],
           'pagenumber': ['viterbi-trellis==0.0.3', 'roman>=3.3', 'numpy>=1.21.3', 'scikit-learn>=1.2.2'],


### PR DESCRIPTION
Owing to a conflict with `archive-ocr-tools`, use `iso-639==0.4.5`

Also of note, DAISY requires two character language codes. See, e.g. `dc:Language` at https://www.daisy.org/z3986/2005/Z3986-2005.html#DCM