### PR TITLE
Feature: Add ISO 639 part2b support for normalize_language

### DIFF
--- a/bin/hocr-to-daisy
+++ b/bin/hocr-to-daisy
@@ -6,9 +6,10 @@ import re
 import xml.etree.ElementTree as ET
 from typing import Dict, List, Optional, OrderedDict
 
-import hocr
+from derivermodule.scandata import \
+    scandata_parse  # type: ignore[import-untyped]
 
-from derivermodule.scandata import scandata_parse  # type: ignore[import-untyped]
+import hocr
 from hocr import daisy
 
 

--- a/bin/hocr-to-daisy
+++ b/bin/hocr-to-daisy
@@ -6,10 +6,8 @@ import re
 import xml.etree.ElementTree as ET
 from typing import Dict, List, Optional, OrderedDict
 
-from internetarchiveocr.language import language_to_alpha3lang  # type: ignore[import-untyped]
-import iso639  # type: ignore[import-untyped]
-
 import hocr
+
 from derivermodule.scandata import scandata_parse  # type: ignore[import-untyped]
 from hocr import daisy
 
@@ -73,10 +71,8 @@ class DaisyGenerator:
         result = []
         for el in md:
             if el.tag == 'language' and el.text:
-                lang = language_to_alpha3lang(el.text)
-                if lang is not None:
-                    result_text = iso639.languages.get(part3=lang).alpha2
-                else:
+                result_text = hocr.util.normalize_language(language=el.text)
+                if not result_text:
                     result_text = el.text
             else:
                 result_text = el.text

--- a/bin/hocr-to-epub
+++ b/bin/hocr-to-epub
@@ -1,18 +1,25 @@
 #!/usr/bin/env python
 
 import argparse
+import os
+import shutil
+import subprocess
+import tarfile
+import zipfile
 from collections import OrderedDict
 from typing import List, Optional
 
-# from PIL.ImageFile import ImageFile
+from ebooklib import epub
+from PIL import Image
 
 import hocr.parse
 import hocr.util
-from ebooklib import epub, ITEM_COVER
 
 try:
     from derivermodule.metadata import parse_item_metadata
-    from derivermodule.scandata import scandata_parse, scandata_get_skip_pages, scandata_get_pagetype_pages
+    from derivermodule.scandata import (scandata_get_pagetype_pages,
+                                        scandata_get_skip_pages,
+                                        scandata_parse)
 except:
     # This is ok, just don't support _meta.xml and _scandata.xml
     # Just error later on when/if the files are actually being passed
@@ -20,14 +27,9 @@ except:
     scandata_get_skip_pages     = None
     scandata_get_pagetype_pages = None
 
-from PIL import Image
+
 Image.MAX_IMAGE_PIXELS = 933120000
 
-import zipfile
-import tarfile
-import os
-import shutil
-import subprocess
 
 KAKADU_ERRORS = [
     'Cannot write output with sample precision in excess of 32 bits per sample',

--- a/bin/hocr-to-epub
+++ b/bin/hocr-to-epub
@@ -20,9 +20,6 @@ except:
     scandata_get_skip_pages     = None
     scandata_get_pagetype_pages = None
 
-from internetarchiveocr.language import language_to_alpha3lang
-import iso639
-
 from PIL import Image
 Image.MAX_IMAGE_PIXELS = 933120000
 
@@ -336,15 +333,6 @@ class EpubGenerator(object):
         print("Parsing file %s" % self.hocr_xml_file_path)
         self.generate()
 
-    def normalize_language(self, language):
-        """
-        Attempt to convert a language tag to a valid country code
-        """
-        try:
-            return iso639.languages.get(part3=language_to_alpha3lang(language)).alpha2
-        except:
-            return language
-
     def set_metadata(self):
         """
         Set the metadata on the epub object
@@ -353,10 +341,10 @@ class EpubGenerator(object):
             self.book.set_identifier(self.metadata['identifier'])
         if 'language' in self.metadata.keys():
             if type(self.metadata['language']) is str:
-                self.metadata['language'] = self.normalize_language(self.metadata['language'])
+                self.metadata['language'] = hocr.util.normalize_language(self.metadata['language'])
                 self.book.set_language(self.metadata['language'])
             elif type(self.metadata['language']) is list:
-                self.metadata['language'] = '; '.join(map(self.normalize_language, self.metadata['language']))
+                self.metadata['language'] = '; '.join(map(hocr.util.normalize_language, self.metadata['language']))
                 self.book.set_language(self.metadata['language'])
         if 'title' in self.metadata.keys():
             if isinstance(self.metadata['title'], str):

--- a/hocr/util.py
+++ b/hocr/util.py
@@ -1,9 +1,11 @@
 import gzip
 import io
-
+from typing import Optional
 from xml.etree import ElementTree
+from PIL import Image
 
-from PIL import Image, ImageChops
+import iso639
+from internetarchiveocr.language import language_to_alpha3lang
 
 #: Contains the HOCR schema
 HOCR_SCHEMA = '{http://www.w3.org/1999/xhtml}'
@@ -153,3 +155,28 @@ def needs_rgb_conversion(image: Image.Image) -> bool:
     Anything that isn't a grayscale image that also isn't already RGB needs conversion.
     """
     return image.mode not in ('RGB', 'L', 'LA', '1')
+
+
+def normalize_language(language) -> Optional[str]:
+    """
+    Attempt to convert a language tag to a valid country code
+    """
+    if not language:
+        return None
+
+    def get_alpha2_code(language: str, part: str) -> Optional[str]:
+        """
+        Try to get a two-character language code from a three character code.
+
+        `part` is an ISO 639 part (e.g. part3, part2b).
+        """
+        try:
+            return iso639.languages.get(**{part: language_to_alpha3lang(language)}).alpha2
+        except KeyError:
+            return None
+
+    alpha2_code = get_alpha2_code(language=language, part="part3")
+    if alpha2_code is None:
+        alpha2_code = get_alpha2_code(language=language, part="part2b")
+
+    return alpha2_code or language

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,8 @@
-from typing import Tuple
-from PIL import Image
 import pytest
+from PIL import Image
 
-from hocr.util import needs_grayscale_conversion, needs_rgb_conversion
+from hocr.util import (needs_grayscale_conversion, needs_rgb_conversion,
+                       normalize_language)
 
 
 def create_image(mode: str, size: tuple = (10, 10)) -> Image.Image:
@@ -56,3 +56,24 @@ def test_needs_grayscale_conversion(mode: str, expected: bool) -> None:
 def test_needs_rgb_conversion(mode: str, expected: bool) -> None:
     image = create_image(mode)
     assert needs_rgb_conversion(image) is expected
+
+
+@pytest.mark.parametrize(
+    ("language", "expected"),
+    [
+        ("fra", "fr"),
+        # See, e.g. https://archive.org/metadata/101610331.nlm.nih.gov/metadata/language
+        ("fre", "fr"),
+        # See, e.g. https://archive.org/metadata/2e013a64-935f-4be4-9c51-3eac22929627/metadata/language
+        ("FRE", "fr"),
+        # See, e.g. https://archive.org/metadata/4E2218INV1398RES_P11BIS/metadata/language
+        ("French", "fr"),
+        ("eNg", "en"),
+        ("brewer", "brewer"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_normalize_language(language: str, expected: str) -> None:
+    got = normalize_language(language=language)
+    assert got == expected


### PR DESCRIPTION
This commit adds support for converting to two characters ISO 639 Part2b languages, e.g. `fre` for French rather than the Part3 `fra`.

IA items will often include `fre`, `ger`, etc., in the metadata language field (see, e.g.
https://archive.org/metadata/101610331.nlm.nih.gov/metadata/language).

But this was being passed through as the literal string `fre` rather than being converted to `fr`. DAISY and Epub readers don't recognize `fra` as a valid languge, and instead display the literal string.