### PR TITLE
DAISY: remove Internet Archive item dependency

### DIFF
--- a/bin/hocr-to-daisy
+++ b/bin/hocr-to-daisy
@@ -6,11 +6,11 @@ import re
 import xml.etree.ElementTree as ET
 from typing import Dict, List, Optional, OrderedDict
 
-from internetarchiveocr.language import language_to_alpha3lang
-import iso639
+from internetarchiveocr.language import language_to_alpha3lang  # type: ignore[import-untyped]
+import iso639  # type: ignore[import-untyped]
 
 import hocr
-from derivermodule.scandata import scandata_parse
+from derivermodule.scandata import scandata_parse  # type: ignore[import-untyped]
 from hocr import daisy
 
 
@@ -23,31 +23,40 @@ class DaisyGenerator:
     def __init__(
         self,
         hocr_xml_file_path: str,
-        ia_item_name: str = "",
-        ia_item_path: str = "",
-        ia_doc_name: str = "",
+        metadata_xml_file_path: Optional[str] = None,
+        scandata_xml_file_path: Optional[str] = None,
+        toc_xml_file_path: Optional[str] = None,
     ) -> None:
         self.hocr_xml_file_path = hocr_xml_file_path
-        self.ia_item_name = ia_item_name
-        self.ia_item_path = ia_item_path
-        self.ia_doc_name = ia_doc_name
-        self.scandata = scandata_parse(self.get_scandata_path())
+        self.metadata_xml_file_path = metadata_xml_file_path
+        self.scandata = (
+            scandata_parse(scandata_xml_file_path) if scandata_xml_file_path else None
+        )
+        self.toc_xml_file_path = toc_xml_file_path
+
+        # TODO: use derivermodule metadata parsing; return rather than set in the process function.
+        if self.metadata_xml_file_path and os.path.exists(self.metadata_xml_file_path):
+            self.process_metadata(self.metadata_xml_file_path)
+
+        processed_metadata = (
+            self.process_metadata(metadata_file_path=args.metafile)
+            if args.metafile
+            else None
+        )
+
+        # Create a DAISY book with which to work.
+        self.daisy_book = daisy.book.DaisyBook(
+            out_name=args.outfile, metadata=processed_metadata
+        )
+        # Fill in the metadata and hOCR content.
+        self.generate(daisy_book=self.daisy_book)
+        # Create the supporting files (ncx, smil, etc.)
+        self.daisy_book.finish(processed_metadata)
 
     def get_hocr(self):
         if os.path.exists(self.hocr_xml_file_path):
             return open(self.hocr_xml_file_path, 'rb')
         raise FileNotFoundError('No hOCR file found')
-
-    def get_scandata_path(self) -> str:
-        paths = [
-            os.path.join(self.ia_item_path, self.ia_doc_name + '_scandata.xml'),
-            os.path.join(self.ia_item_path, 'scandata.xml'),
-            os.path.join(self.ia_item_path, 'scandata.zip'),
-        ]
-        for sd_path in paths:
-            if os.path.exists(sd_path):
-                return sd_path
-        raise FileNotFoundError('No scandata found')
 
     # TODO: candidate for removal/refactor
     def get_bookdata(self) -> OrderedDict:
@@ -59,11 +68,8 @@ class DaisyGenerator:
         return book_data
 
     # TODO: candidate for removal/refactor
-    def get_metadata(self) -> List[Dict[str, str]]:
-        if self.metadata:
-            return self.metadata
-        md_path = os.path.join(self.ia_item_path, self.ia_item_name + '_meta.xml')
-        md = ET.parse(md_path).getroot()
+    def process_metadata(self, metadata_file_path: str) -> List[Dict[str, str]]:
+        md = ET.parse(metadata_file_path).getroot()
         result = []
         for el in md:
             if el.tag == 'language' and el.text:
@@ -78,13 +84,14 @@ class DaisyGenerator:
         self.metadata = result
         return result
 
-    def get_toc(self):
+    def get_toc(self) -> Optional[Dict]:
+        if self.toc_xml_file_path is None:
+            return None
         if self.toc is not None:
             return self.toc
-        toc_path = os.path.join(self.ia_item_path, self.ia_doc_name + '_toc.xml')
-        if not os.path.exists(toc_path):
+        if not os.path.exists(self.toc_xml_file_path):
             return None
-        toc = ET.parse(toc_path).getroot()
+        toc = ET.parse(self.toc_xml_file_path).getroot()
         result = {el.get('page'): el.get('title') for el in toc}
         return result
 
@@ -100,6 +107,9 @@ class DaisyGenerator:
 
     def get_page_scandata(self, page_number: int) -> Optional[OrderedDict]:
         """Get the scandata for an individual page."""
+        if not self.scandata:
+            return None
+
         pages = self.get_scandata_pages()
         if page_number > len(pages):
             return None
@@ -140,7 +150,6 @@ class DaisyGenerator:
 
     # TODO: candidate for removal/refactor
     def our_hocr_paragraph_text(self, paragraph):
-        word_confidences = []
         par_text = ''
 
         for line in paragraph['lines']:
@@ -156,7 +165,6 @@ class DaisyGenerator:
 
             # Encode
             line_words = line_words.encode('utf-8')
-            # line_words = line_words.strip().encode('utf-8')
 
             # Write out
             if line_words:
@@ -168,26 +176,38 @@ class DaisyGenerator:
 
         return par_text
 
-    def process_book_hocr(self, ebook: "daisy.book.DaisyBook", alt_booktext=None):
+    def generate(self, daisy_book: "daisy.book.DaisyBook", alt_booktext=None):
+        """
+        Take a DaisyBook and fill it out data from the hOCR file, scandata,
+        and metadata, if available. Also add frontmatter and rearmatter.
+        """
         hocr_file = self.get_hocr()
-        contents = self.get_toc()
-        metadata = self.get_metadata()
+        contents = self.get_toc() if self.toc_xml_file_path is not None else None
+        metadata = (
+            self.process_metadata(self.metadata_xml_file_path)
+            if self.metadata_xml_file_path
+            else None
+        )
 
-        title = daisy.book.get_metadata_tag_data(metadata, 'title')
+        title = (
+            daisy.book.get_metadata_tag_data(metadata, 'title') if metadata else None
+        )
         if title is None:
             title = ''
 
-        author = daisy.book.get_metadata_tag_data(metadata, 'creator')
+        author = (
+            daisy.book.get_metadata_tag_data(metadata, 'creator') if metadata else None
+        )
         if author is None:
             author = ''
 
-        ebook.push_tag('frontmatter')
-        ebook.add_tag('doctitle', title)
-        ebook.add_tag('docauthor', author)
+        daisy_book.push_tag('frontmatter')
+        daisy_book.add_tag('doctitle', title)
+        daisy_book.add_tag('docauthor', author)
 
-        ebook.push_navpoint('level', 'h', 'Producer\'s Note')
-        ebook.push_navpoint('level', 'h', 'About Internet Archive Daisy Books')
-        ebook.add_tag(
+        daisy_book.push_navpoint('level', 'h', 'Producer\'s Note')
+        daisy_book.push_navpoint('level', 'h', 'About Internet Archive Daisy Books')
+        daisy_book.add_tag(
             'p',
             """This book was produced in DAISY format by the Internet Archive.  The
         book pages were scanned and converted to DAISY format
@@ -200,22 +220,22 @@ class DaisyGenerator:
         that this book will be useful to you.
         """,
         )
-        ebook.pop_navpoint()
-        ebook.push_navpoint('level', 'h', 'About this DAISY book')
+        daisy_book.pop_navpoint()
+        daisy_book.push_navpoint('level', 'h', 'About this DAISY book')
         has_nav = False
-        if self.has_pagenos():
+        if self.scandata and self.has_pagenos():
             has_nav = True
-            ebook.add_tag('p', "This book has page navigation.")
+            daisy_book.add_tag('p', "This book has page navigation.")
         if contents is not None:
             has_nav = True
-            ebook.add_tag('p', "This book has chapter navigation.")
+            daisy_book.add_tag('p', "This book has chapter navigation.")
         if not has_nav:
-            ebook.add_tag(
+            daisy_book.add_tag(
                 'p', "This book as paragraph navigation, but is otherwise unstructured."
             )
-        ebook.pop_navpoint()
-        ebook.push_navpoint('level', 'h', 'About the Internet Archive')
-        ebook.add_tag(
+        daisy_book.pop_navpoint()
+        daisy_book.push_navpoint('level', 'h', 'About the Internet Archive')
+        daisy_book.add_tag(
             'p',
             """The Internet Archive was founded in 1996
         to build an Internet library
@@ -228,27 +248,25 @@ class DaisyGenerator:
     for the blind and other persons with disabilities.
         """,
         )
-        ebook.pop_navpoint()
-        ebook.pop_navpoint()
+        daisy_book.pop_navpoint()
+        daisy_book.pop_navpoint()
 
-        ebook.pop_tag()
-        ebook.push_tag('bodymatter')
+        daisy_book.pop_tag()
+        daisy_book.push_tag('bodymatter')
 
         if contents is None:
-            ebook.push_navpoint('level', 'h', 'Book')
+            daisy_book.push_navpoint('level', 'h', 'Book')
 
-        part_number = 0
-        cover_number = 0
         pushed_navpoint = False
 
         hocr_iterator = hocr.parse.hocr_page_iterator(hocr_file)
 
-        before_title_page = True
+        before_title_page = True if self.scandata else False
         for i, page in enumerate(hocr_iterator):
             # wrap in try/finally to ensure page.clear() is called
             try:
                 if alt_booktext is not None:
-                    ebook.add_tag('p', alt_booktext)
+                    daisy_book.add_tag('p', alt_booktext)
                     break
 
                 page_scandata = self.get_page_scandata(i)
@@ -258,18 +276,18 @@ class DaisyGenerator:
                 if pageno is not None:
                     if contents is not None and pageno in contents:
                         if pushed_navpoint:
-                            ebook.pop_navpoint()
-                        ebook.push_navpoint('level', 'h', contents[pageno])
+                            daisy_book.pop_navpoint()
+                        daisy_book.push_navpoint('level', 'h', contents[pageno])
                         pushed_navpoint = True
-                    ebook.add_pagetarget(pageno, pageno)
+                    daisy_book.add_pagetarget(pageno, pageno)
 
-                if not page_scandata:
-                    continue
-
-                if page_scandata.get('pageType', '').lower() in ('title', 'title page'):
+                if page_scandata and page_scandata.get('pageType', '').lower() in (
+                    'title',
+                    'title page',
+                ):
                     before_title_page = False
 
-                if page_scandata.get('addToAccessFormats') == 'false':
+                if page_scandata and page_scandata.get('addToAccessFormats') == 'false':
                     continue
 
                 if before_title_page:
@@ -298,22 +316,22 @@ class DaisyGenerator:
                         continue
 
                     par_text = self.our_hocr_paragraph_text(par)
-                    ebook.add_tag('p', par_text)
+                    daisy_book.add_tag('p', par_text)
             finally:
                 pass
 
         if pushed_navpoint:
-            ebook.pop_navpoint()
+            daisy_book.pop_navpoint()
 
         if contents is None:
-            ebook.pop_navpoint()  # level1
+            daisy_book.pop_navpoint()  # level1
 
-        ebook.pop_tag()
-        ebook.push_tag('rearmatter')
-        ebook.push_tag('level1')
-        ebook.add_tag('p', 'End of book')
-        ebook.pop_tag()
-        ebook.pop_tag()
+        daisy_book.pop_tag()
+        daisy_book.push_tag('rearmatter')
+        daisy_book.push_tag('level1')
+        daisy_book.add_tag('p', 'End of book')
+        daisy_book.pop_tag()
+        daisy_book.pop_tag()
 
 
 if __name__ == '__main__':
@@ -326,24 +344,20 @@ if __name__ == '__main__':
         '-o', '--outfile', help='Output DAISY zip', type=str, default=None
     )
     parser.add_argument(
+        '-m', '--metafile', help='Item _meta.xml file', type=str, default=None
+    )
+    parser.add_argument(
+        '-s', '--scandata', help='Item _scandata.xml file', type=str, default=None
+    )
+    parser.add_argument(
+        '-t', '--toc', help='Item _toc.xml file', type=str, default=None
+    )
+    parser.add_argument(
         '-w',
         '--workingdir',
         help='Directory used for temp files',
         type=str,
         default=None,
-    )
-    parser.add_argument(
-        '-i',
-        '--itemdir',
-        help='Directory of the Internet Archive item',
-        type=str,
-        default=None,
-    )
-    parser.add_argument(
-        '-n', '--itemname', help='Internet Archive item name', type=str, default=None
-    )
-    parser.add_argument(
-        '-d', '--docname', help='Internet Archive document name', type=str, default=None
     )
 
     args = parser.parse_args()
@@ -355,16 +369,9 @@ if __name__ == '__main__':
     if args.workingdir:
         WORKING_DIR = args.workingdir
 
-    # The relation of these will need to be rethought.
-    # TODO: should be args.infile
     dg = DaisyGenerator(
         hocr_xml_file_path=args.infile,
-        ia_item_name=args.itemname,
-        ia_item_path=args.itemdir,
-        ia_doc_name=args.docname,
+        metadata_xml_file_path=args.metafile,
+        scandata_xml_file_path=args.scandata,
+        toc_xml_file_path=args.toc,
     )
-    metadata = dg.get_metadata()
-
-    daisy_book = daisy.book.DaisyBook(out_name=args.outfile, metadata=metadata)
-    dg.process_book_hocr(ebook=daisy_book)
-    daisy_book.finish(metadata)

--- a/bin/hocr-to-daisy
+++ b/bin/hocr-to-daisy
@@ -4,23 +4,21 @@ import argparse
 import os
 import re
 import xml.etree.ElementTree as ET
-import zipfile
-from typing import Dict, List
+from typing import Dict, List, Optional, OrderedDict
 
 from internetarchiveocr.language import language_to_alpha3lang
 import iso639
 
 import hocr
+from derivermodule.scandata import scandata_parse
 from hocr import daisy
 
 
 class DaisyGenerator:
     __version__ = '1.0.0'
 
-    # TODO fix pathing and other hard-coded values. Look at ebook script.
     toc = None
     metadata = None
-    scandata = None
 
     def __init__(
         self,
@@ -33,14 +31,13 @@ class DaisyGenerator:
         self.ia_item_name = ia_item_name
         self.ia_item_path = ia_item_path
         self.ia_doc_name = ia_doc_name
+        self.scandata = scandata_parse(self.get_scandata_path())
 
-    # TODO: candidate for removal/refactor
     def get_hocr(self):
         if os.path.exists(self.hocr_xml_file_path):
             return open(self.hocr_xml_file_path, 'rb')
         raise FileNotFoundError('No hOCR file found')
 
-    # TODO: candidate for removal/refactor
     def get_scandata_path(self) -> str:
         paths = [
             os.path.join(self.ia_item_path, self.ia_doc_name + '_scandata.xml'),
@@ -50,59 +47,16 @@ class DaisyGenerator:
         for sd_path in paths:
             if os.path.exists(sd_path):
                 return sd_path
-        raise Exception('No scandata found')
-
-    def set_namespace(self) -> None:
-        """
-        Set the namespace, if any, because Python's XML.etree won't work without
-        it, if it is present. But not all scandata files have a namespace
-        specified.
-        """
-        self.namespace = ''
-        root = self.scandata
-        if root.tag.startswith('{'):
-            self.namespace = '{' + root.tag.split('}')[0][1:] + '}'
+        raise FileNotFoundError('No scandata found')
 
     # TODO: candidate for removal/refactor
-    def get_scandata(self) -> ET.Element:
-        if self.scandata is None:
-            scandata_path = self.get_scandata_path()
-            _, ext = os.path.splitext(scandata_path)
+    def get_bookdata(self) -> OrderedDict:
+        """Get the `book` metadata from scandata."""
+        book_data = self.scandata.get("book")
+        if not book_data:
+            raise ValueError("Expected book data")
 
-            if ext.lower() == '.zip':
-                with zipfile.ZipFile(scandata_path, 'r') as z:
-                    scandata_str = z.read('scandata.xml')
-                    self.scandata = ET.fromstring(scandata_str)
-            else:
-                self.scandata = ET.parse(scandata_path).getroot()
-
-            self.set_namespace()
-            pageData = self.scandata.find(f'{self.namespace}pageData')
-            if pageData is not None:
-                self.scandata_pages = pageData.findall(f'{self.namespace}page')
-
-            self.leaves = {
-                int(page.get('leafNum', 0)): page for page in self.scandata_pages
-            }
-        return self.scandata
-
-    # TODO: candidate for removal/refactor
-    def get_scandata_ns(self) -> str:
-        scandata = self.get_scandata()
-        bookData = scandata.find('bookData')
-        if bookData is None:
-            return '{http://archive.org/scribe/xml}'
-        else:
-            return ''
-
-    # TODO: candidate for removal/refactor
-    def get_bookdata(self) -> ET.Element:
-        scandata = self.get_scandata()
-        bookdata = scandata.find(self.get_scandata_ns() + 'bookData')
-        if bookdata is None:
-            raise ValueError('why here?')
-            # bookdata = scandata.bookData
-        return bookdata
+        return book_data
 
     # TODO: candidate for removal/refactor
     def get_metadata(self) -> List[Dict[str, str]]:
@@ -124,7 +78,6 @@ class DaisyGenerator:
         self.metadata = result
         return result
 
-    # TODO: candidate for removal/refactor
     def get_toc(self):
         if self.toc is not None:
             return self.toc
@@ -135,32 +88,27 @@ class DaisyGenerator:
         result = {el.get('page'): el.get('title') for el in toc}
         return result
 
-    # TODO: candidate for removal/refactor
     def has_pagenos(self) -> bool:
-        self.get_scandata()
-        max_page = len(self.scandata_pages) if self.scandata_pages else 0
-        i = 0
-        result = False
-        while i < max_page:
-            page_scandata = self.get_page_scandata(i)
-            pageno = page_scandata.find(self.get_scandata_ns() + 'pageNumber')
-            if pageno is not None:
-                result = True
-                break
-            i += 1
-        return result
+        """Determine whether the book has page numbers."""
+        pages = self.get_scandata_pages()
+        for page in pages:
+            has_pagenumber = page.get("pageNumber")
+            if has_pagenumber is not None:
+                return True
 
-    # TODO: candidate for removal/refactor
-    def get_page_scandata(self, i: int) -> ET.Element:
-        self.get_scandata()
-        if i >= len(self.scandata_pages):
+        return False
+
+    def get_page_scandata(self, page_number: int) -> Optional[OrderedDict]:
+        """Get the scandata for an individual page."""
+        pages = self.get_scandata_pages()
+        if page_number > len(pages):
             return None
-        return self.scandata_pages[int(i)]
+        return pages[int(page_number)]
 
-    # TODO: candidate for removal/refactor
-    def get_scandata_pages(self) -> List[ET.Element]:
-        self.get_scandata()
-        return self.scandata_pages
+    def get_scandata_pages(self) -> List[OrderedDict]:
+        """Return the scandata pages data."""
+        book = self.get_bookdata()
+        return book['pageData']['page']
 
     # TODO: candidate for removal/refactor
     def par_is_pageno_header_footer_hocr(self, par) -> bool:
@@ -221,18 +169,14 @@ class DaisyGenerator:
         return par_text
 
     def process_book_hocr(self, ebook: "daisy.book.DaisyBook", alt_booktext=None):
-        # TODO: maybe ultimately just make the initial DaisyBook here?
-        scandata = self.get_scandata()
         hocr_file = self.get_hocr()
-
-        scandata_ns = self.get_scandata_ns()
-        bookData = self.get_bookdata()
-
         contents = self.get_toc()
         metadata = self.get_metadata()
+
         title = daisy.book.get_metadata_tag_data(metadata, 'title')
         if title is None:
             title = ''
+
         author = daisy.book.get_metadata_tag_data(metadata, 'creator')
         if author is None:
             author = ''
@@ -299,15 +243,7 @@ class DaisyGenerator:
 
         hocr_iterator = hocr.parse.hocr_page_iterator(hocr_file)
 
-        found_title = False
-        for page_scandata in self.get_scandata_pages():  # confirm title exists
-            # TODO: handle `None`
-            t = page_scandata.find(f'{self.namespace}pageType').text
-            if t == 'Title' or t == 'Title Page':
-                found_title = True
-                break
-        # True if no title found, else False now, True later.
-        before_title_page = found_title
+        before_title_page = True
         for i, page in enumerate(hocr_iterator):
             # wrap in try/finally to ensure page.clear() is called
             try:
@@ -318,79 +254,51 @@ class DaisyGenerator:
                 page_scandata = self.get_page_scandata(i)
                 pageno = None
                 if page_scandata is not None:
-                    pageno = page_scandata.find(scandata_ns + 'pageNumber')
-                    if pageno is not None:
-                        pageno = pageno.text
+                    pageno = page_scandata.get('pageNumber')
                 if pageno is not None:
                     if contents is not None and pageno in contents:
                         if pushed_navpoint:
                             ebook.pop_navpoint()
                         ebook.push_navpoint('level', 'h', contents[pageno])
                         pushed_navpoint = True
-                    part_str = 'part' + str(part_number).zfill(4)
                     ebook.add_pagetarget(pageno, pageno)
 
-                def include_page(page_scandata):
-                    if page_scandata is None:
-                        return False
-                    add = page_scandata.find(scandata_ns + 'addToAccessFormats')
-                    if add is None:
-                        add = page_scandata.addToAccessFormats
-                    return bool(add is not None and add.text == 'true')
-
-                if not include_page(page_scandata):
+                if not page_scandata:
                     continue
 
-                # TODO: handle None
-                page_type = page_scandata.find(f'{self.namespace}pageType').text.lower()
-                add_to_access_formats = page_scandata.find(
-                    f'{self.namespace}addToAccessFormats'
-                ).text.lower()
-                if page_type == 'cover':
-                    pass
-
-                elif page_type == 'title' or page_type == 'title page':
+                if page_scandata.get('pageType', '').lower() in ('title', 'title page'):
                     before_title_page = False
-                    pass
 
-                elif page_type == 'copyright':
-                    pass
+                if page_scandata.get('addToAccessFormats') == 'false':
+                    continue
 
-                elif page_type == 'contents':
-                    pass
+                if before_title_page:
+                    continue
 
-                elif page_type == 'normal' or add_to_access_formats == 'true':
-                    # Treat pages with unrecognized pageType and add_to_access_formats=true as Normal
-                    if before_title_page:
-                        # XXX consider skipping if blank + no words?
-                        # make page image
-                        # (id, filename) = make_html_page_image(i, iabook, ebook)
-                        pass
-                    else:
-                        first_par = True
-                        saw_pageno_header_footer = False
+                first_par = True
+                saw_pageno_header_footer = False
 
-                        pars = list(hocr.parse.hocr_page_to_word_data(page))
+                pars = list(hocr.parse.hocr_page_to_word_data(page))
 
-                        for paridx, par in enumerate(pars):
-                            # First paragraph
-                            if first_par and self.par_is_pageno_header_footer_hocr(par):
-                                saw_pageno_header_footer = True
-                                first_par = False
-                                continue
-                            first_par = False
+                for paridx, par in enumerate(pars):
+                    # First paragraph
+                    if first_par and self.par_is_pageno_header_footer_hocr(par):
+                        saw_pageno_header_footer = True
+                        first_par = False
+                        continue
+                    first_par = False
 
-                            # Last paragraph
-                            if (
-                                not saw_pageno_header_footer
-                                and paridx == len(pars) - 1
-                                and self.par_is_pageno_header_footer_hocr(par)
-                            ):
-                                saw_pageno_header_footer = True
-                                continue
+                    # Last paragraph
+                    if (
+                        not saw_pageno_header_footer
+                        and paridx == len(pars) - 1
+                        and self.par_is_pageno_header_footer_hocr(par)
+                    ):
+                        saw_pageno_header_footer = True
+                        continue
 
-                            par_text = self.our_hocr_paragraph_text(par)
-                            ebook.add_tag('p', par_text)
+                    par_text = self.our_hocr_paragraph_text(par)
+                    ebook.add_tag('p', par_text)
             finally:
                 pass
 
@@ -406,12 +314,6 @@ class DaisyGenerator:
         ebook.add_tag('p', 'End of book')
         ebook.pop_tag()
         ebook.pop_tag()
-
-    def generate(self):
-        """
-        TODO:
-            Maybe this can more or less run process_book_hocr() from www/daisy.
-        """
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Depends on #13. The relevant changes for this particular PR are in e365988f80b8fdbb2993eb6f3e43c3243124158b.

To the extent IA item metadata is available, it will be used, but now the minimum requirement is an hOCR file and an output file.

Minimum invocation:
```
❯ PYTHONPATH=. ./bin/hocr-to-daisy -f ./sim_english-illustrated-magazine_1884-12_2_15_hocr.html \
-o test_daisy_output.zip
```
https://archive.org/details/sim_english-illustrated-magazine_1884-12_2_15
![image](https://github.com/user-attachments/assets/ff99e258-ceb3-4412-8711-dfa4502f3647)
![image](https://github.com/user-attachments/assets/79643305-5ba3-4d50-b543-d8d1032164a5)

(Nearly) Maximal invocation (without TOC):
```
❯ PYTHONPATH=. ./bin/hocr-to-daisy -f /home/scott/Downloads/daisy/items/sim_english-illustrated-magazine_1884-12_2_15/sim_english-illustrated-magazine_1884-12_2_15_hocr.html \
-m /home/scott/Downloads/daisy/items/sim_english-illustrated-magazine_1884-12_2_15/sim_english-illustrated-magazine_1884-12_2_15_meta.xml \
-s /home/scott/Downloads/daisy/items/sim_english-illustrated-magazine_1884-12_2_15/sim_english-illustrated-magazine_1884-12_2_15_scandata.xml \
-o test_daisy_output.zip
```
![image](https://github.com/user-attachments/assets/82b6b23d-e9ca-42f2-9709-bf89575187e8)
![image](https://github.com/user-attachments/assets/f56a6837-be6b-43f3-b956-9e3be3d55b3d)

It's not pictured, but the (nearly) maximal option also includes page numbers in the DAISY, where as the minimal option does not include these.