### PR TITLE
EPUB: convert images to 8 bit prior to saving as JPEG

### DIFF
--- a/bin/hocr-to-epub
+++ b/bin/hocr-to-epub
@@ -3,6 +3,8 @@
 import argparse
 from collections import OrderedDict
 
+# from PIL.ImageFile import ImageFile
+
 import hocr.parse
 import hocr.util
 from ebooklib import epub, ITEM_COVER
@@ -129,6 +131,11 @@ class ImageStack(object):
 
         #fh = self.zf.open(self.filenames[page])
         img = Image.open(tempfile_tiff)
+        if hocr.util.needs_grayscale_conversion(image=img):
+            img = img.convert('L')
+        elif hocr.util.needs_rgb_conversion(image=img):
+            img = img.convert('RGB')
+
         #img = Image.open(fh)
         if box:
             region = img.crop(box)

--- a/hocr/util.py
+++ b/hocr/util.py
@@ -3,6 +3,8 @@ import io
 
 from xml.etree import ElementTree
 
+from PIL import Image, ImageChops
+
 #: Contains the HOCR schema
 HOCR_SCHEMA = '{http://www.w3.org/1999/xhtml}'
 
@@ -130,3 +132,24 @@ def get_header_footer(fd):
 
     return header.encode('utf-8'), footer.encode('utf-8')
 
+
+def needs_grayscale_conversion(image: Image.Image) -> bool:
+    """
+    Return True if image should be converted to grayscale, and False otherwise.
+    Grayscale images with alpha layers need conversion because the JPEG target
+    doesn't support transparency.
+
+    Note: this will return False for RGB images that are functionally grayscale,
+    as the cost of identifying them is not worth the effort. For a good, yet
+    still too slow strategy, see https://stackoverflow.com/a/34175631.
+    """
+    return image.mode in ('LA', '1')
+
+
+def needs_rgb_conversion(image: Image.Image) -> bool:
+    """
+    Return True if image should be converted to RGB, and False otherwise.
+
+    Anything that isn't a grayscale image that also isn't already RGB needs conversion.
+    """
+    return image.mode not in ('RGB', 'L', 'LA', '1')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,58 @@
+from typing import Tuple
+from PIL import Image
+import pytest
+
+from hocr.util import needs_grayscale_conversion, needs_rgb_conversion
+
+
+def create_image(mode: str, size: tuple = (10, 10)) -> Image.Image:
+    """
+    Helper function to create a Pillow Image of type `mode`.
+    See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes.
+    """
+    return Image.new(mode, size)
+
+
+@pytest.mark.parametrize(
+    ('mode', 'expected'),
+    [
+        # Grayscale with alpha channel
+        ('LA', True),
+        # 1 bit pixels, black and white
+        ('1', True),
+        # Grayscale without alpha channel
+        ('L', False),
+        # 16-bit unsigned integer pixel
+        ('I;16', False),
+        # RGB image
+        ('RGB', False),
+    ],
+)
+def test_needs_grayscale_conversion(mode: str, expected: bool) -> None:
+    """This does not test for functionally grayscale RGB images."""
+    image = create_image(mode)
+    assert needs_grayscale_conversion(image) is expected
+
+
+@pytest.mark.parametrize(
+    ('mode', 'expected'),
+    [
+        # RGBA image
+        ('RGBA', True),
+        # CMYK image
+        ('CMYK', True),
+        # 16-bit unsigned integer pixel
+        ('I;16', True),
+        # Grayscale with alpha channel
+        ('LA', False),
+        # 1 bit pixels, black and white
+        ('1', False),
+        # Grayscale without alpha channel
+        ('L', False),
+        # RGB image
+        ('RGB', False),
+    ],
+)
+def test_needs_rgb_conversion(mode: str, expected: bool) -> None:
+    image = create_image(mode)
+    assert needs_rgb_conversion(image) is expected


### PR DESCRIPTION
This commit fixes a pair of errors related to saving images as `JPEG`. In the first case, it addresses an error whereby a 16 bit `TIFF` would raise an `OSError` when trying to save as `JPEG`, owing to `JPEG`'s 8 bit limitation.

In the second case, it addresses an error whereby the image is palette based, and the image won't convert to `JPEG`.

In both cases the fix is to convert with `RGB` so the `JPEG` can generate.

The solution here is more general in that grayscale images that have an alpha channel will have that removed, and anything that isn't grayscale or RGB will be converted to RGB.

Functionally grayscale RGB images with the same color on each channel will be converted to grayscale also.

The 16 bit error is as follows:
```
Traceback (most recent call last):
  File "/usr/local/bin/hocr-to-epub", line 672, in
    EpubGenerator(args.infile, args.metafile, args.imagestack, args.scandata, args.outfile, use_kakadu=args.kakadu)
  File "/usr/local/bin/hocr-to-epub", line 291, in __init__
    self.generate()
  File "/usr/local/bin/hocr-to-epub", line 590, in generate
    cropped_image_filename = self.img_stack.crop_image(page_idx, box)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/hocr-to-epub", line 132, in crop_image
    region.save(output_filename)
  File "/usr/local/lib/python3.12/site-packages/PIL/Image.py", line 2568, in save
    save_handler(self, fp, filename)
  File "/usr/local/lib/python3.12/site-packages/PIL/JpegImagePlugin.py", line 642, in _save
    raise OSError(msg) from e
OSError: cannot write mode I;16 as JPEG
```
Sample item: https://archive.org/download/ColibriesdeMexi00Ariz

The palette error is as follows:
```
Traceback (most recent call last):
  File "/usr/local/bin/hocr-to-epub", line 684, in
    EpubGenerator(args.infile, args.metafile, args.imagestack, args.scandata, args.outfile, use_kakadu=args.kakadu)
  File "/usr/local/bin/hocr-to-epub", line 294, in __init__
    self.generate()
  File "/usr/local/bin/hocr-to-epub", line 602, in generate
    cropped_image_filename = self.img_stack.crop_image(page_idx, box)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/hocr-to-epub", line 135, in crop_image
    region.save(output_filename)
  File "/usr/local/lib/python3.12/site-packages/PIL/Image.py", line 2568, in save
    save_handler(self, fp, filename)
  File "/usr/local/lib/python3.12/site-packages/PIL/JpegImagePlugin.py", line 642, in _save
    raise OSError(msg) from e
OSError: cannot write mode P as JPEG
```
Sample item: https://archive.org/download/jiltandothersto00readgoog