### PR TITLE
DAISY fix: if no item title, set the book title to the identifier

### DIFF
--- a/hocr/daisy/book.py
+++ b/hocr/daisy/book.py
@@ -395,6 +395,8 @@ def make_dtbook(book_id: str, title: str) -> Tuple[ET.ElementTree, ET.Element]:
         {'xmlns': 'http://www.daisy.org/z3986/2005/dtbook/', 'version': '2005-3'},
     )
 
+    title = title if title else book_id
+
     head_el = ET.SubElement(root_el, 'head')
     ET.SubElement(head_el, 'meta', {'name': 'dtb:uid', 'content': book_id})
     ET.SubElement(head_el, 'meta', {'name': 'dc:Title', 'content': title})


### PR DESCRIPTION
This commit uses the item `identifier` as the book title if the item is lacking a `title` in its metadata.

The DASIY spec requires a title:
https://daisy.org/activities/standards/daisy/daisy-3/z39-86-2005-r2012-specifications-for-the-digital-talking-book/